### PR TITLE
Improve performance for TreeSearch

### DIFF
--- a/editor/task_tree.cpp
+++ b/editor/task_tree.cpp
@@ -538,8 +538,8 @@ void TaskTree::_notification(int p_what) {
 			tree->connect("multi_selected", callable_mp(this, &TaskTree::_on_item_selected).unbind(3), CONNECT_DEFERRED);
 			tree->connect("item_activated", callable_mp(this, &TaskTree::_on_item_activated));
 			tree->connect("item_collapsed", callable_mp(this, &TaskTree::_on_item_collapsed));
-			tree_search_panel->connect("update_requested", callable_mp(this, &TaskTree::_update_tree));
-			tree_search_panel->connect("visibility_changed", callable_mp(this, &TaskTree::_update_tree));
+			tree_search_panel->connect("update_requested", callable_mp(tree_search.ptr(), &TreeSearch::update_search).bind(tree));
+			tree_search_panel->connect("visibility_changed", callable_mp(tree_search.ptr(), &TreeSearch::update_search).bind(tree));
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			_do_update_theme_item_cache();

--- a/editor/tree_search.cpp
+++ b/editor/tree_search.cpp
@@ -46,11 +46,10 @@ void TreeSearch::_clean_callable_cache() {
 	HashMap<TreeItem *, Callable> new_callable_cache;
 	new_callable_cache.reserve(callable_cache.size()); // Efficiency
 
-	for (HashMap<TreeItem *, Callable>::Iterator it_cache = callable_cache.begin(); it_cache != callable_cache.end(); ++it_cache) {
-		TreeItem *cur_item = it_cache->key;
-		if (_vector_has_bsearch(ordered_tree_items, cur_item)) {
-			// Additional check for `cur_item->get_custom_draw_callback(0) == it_cache->value` more correct, but also more expensive.
-			new_callable_cache[cur_item] = it_cache->value;
+	for (int i = 0; i < ordered_tree_items.size(); i++) {
+		TreeItem *cur_item = ordered_tree_items[i];
+		if (callable_cache.has(cur_item)) {
+			new_callable_cache[cur_item] = callable_cache[cur_item];
 		}
 	}
 	callable_cache = new_callable_cache;
@@ -94,8 +93,8 @@ void TreeSearch::_clear_filter() {
 
 void TreeSearch::_highlight_tree() {
 	ERR_FAIL_COND(!tree_reference);
-	for (int i = 0; i < ordered_tree_items.size(); i++) {
-		TreeItem *tree_item = ordered_tree_items[i];
+	for (int i = 0; i < matching_entries.size(); i++) {
+		TreeItem *tree_item = matching_entries[i];
 		_highlight_tree_item(tree_item);
 	}
 	tree_reference->queue_redraw();
@@ -113,7 +112,7 @@ void TreeSearch::_highlight_tree_item(TreeItem *p_tree_item) {
 	if (p_tree_item->get_cell_mode(0) == TreeItem::CELL_MODE_CUSTOM) {
 		parent_draw_method = p_tree_item->get_custom_draw_callback(0);
 	}
-	
+
 	// if the cached draw method is already applied, do nothing.
 	if (callable_cache.has(p_tree_item) && parent_draw_method == callable_cache.get(p_tree_item)){
 		return;
@@ -236,11 +235,6 @@ void TreeSearch::_update_ordered_tree_items(TreeItem *p_tree_item) {
 	while (child) {
 		_update_ordered_tree_items(child);
 		child = child->get_next();
-	}
-
-	// If this is the root item, sort the list
-	if (p_tree_item == p_tree_item->get_tree()->get_root()) {
-		ordered_tree_items.sort();
 	}
 }
 

--- a/editor/tree_search.h
+++ b/editor/tree_search.h
@@ -60,7 +60,9 @@ private:
 
 	// Update_search() calls these
 	void _filter_tree(const String &p_search_mask);
-	void _highlight_tree(const String &p_search_mask);
+	void _highlight_tree();
+
+	void _highlight_tree_item(TreeItem *p_tree_item);
 
 	// Custom draw-Callback (bind inherited Callable).
 	void _draw_highlight_item(TreeItem *p_tree_item, Rect2 p_rect, Callable p_parent_draw_method);

--- a/editor/tree_search.h
+++ b/editor/tree_search.h
@@ -57,9 +57,12 @@ private:
 	Vector<TreeItem *> matching_entries;
 	HashMap<TreeItem *, int> number_matches;
 	HashMap<TreeItem *, Callable> callable_cache;
+	bool was_searched_recently = false;
+	bool has_been_filtered_recently = false;
 
 	// Update_search() calls these
 	void _filter_tree(const String &p_search_mask);
+	void _clear_filter();
 	void _highlight_tree();
 
 	void _highlight_tree_item(TreeItem *p_tree_item);

--- a/editor/tree_search.h
+++ b/editor/tree_search.h
@@ -57,8 +57,10 @@ private:
 	Vector<TreeItem *> matching_entries;
 	HashMap<TreeItem *, int> number_matches;
 	HashMap<TreeItem *, Callable> callable_cache;
-	bool was_searched_recently = false;
-	bool has_been_filtered_recently = false;
+	bool was_searched_recently = false; // Performance
+	bool was_filtered_recently = false; // Performance
+
+	void _clean_callable_cache();
 
 	// Update_search() calls these
 	void _filter_tree(const String &p_search_mask);

--- a/editor/tree_search.h
+++ b/editor/tree_search.h
@@ -53,10 +53,12 @@ private:
 
 	// For TaskTree: These are updated when the tree is updated through TaskTree::_create_tree.
 	Tree *tree_reference;
+
 	Vector<TreeItem *> ordered_tree_items;
 	Vector<TreeItem *> matching_entries;
 	HashMap<TreeItem *, int> number_matches;
 	HashMap<TreeItem *, Callable> callable_cache;
+
 	bool was_searched_recently = false; // Performance
 	bool was_filtered_recently = false; // Performance
 
@@ -65,8 +67,8 @@ private:
 	// Update_search() calls these
 	void _filter_tree(const String &p_search_mask);
 	void _clear_filter();
-	void _highlight_tree();
 
+	void _highlight_tree();
 	void _highlight_tree_item(TreeItem *p_tree_item);
 
 	// Custom draw-Callback (bind inherited Callable).


### PR DESCRIPTION
Addresses https://github.com/limbonaut/limboai/pull/229 -> Searches do a whole tree reconstruction for now: Noticeable lag.
- ~~Make `search_mask` updates not reconstruct the Tree via `TaskTree`~~
- ~~Optimize callable_cache management~~
- ~~Selectively clear filter only when previously applied~~
- ~~Use `Tree::queue_redraw` when possible instead of reassigning the draw callback.~~